### PR TITLE
Add separate copyright and license sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,12 @@ The TypeScript code must be compiled:
 
     npx lerna add <package> path/to/subpackage
 
+Copyright
+---------
+
+All files in this repository are **Copyright (C) 2020 National Research Council Canada.**
+
 License
 -------
 
-2020 © National Research Council of Canada. MIT Licensed. See LICENSE for details.
+All files in this repository are released under the MIT licence. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Added separate sections to distinguish copyright from the licence. This is especially important for the MIT licence which is the most "free" one. There seems to be files in the repository that were NOT written by NRC staff, so I will likely have to update the copyright statement accordingly.